### PR TITLE
Added Indian Institute Of Technology, Roorkee

### DIFF
--- a/lib/domains/ac.in/iitr
+++ b/lib/domains/ac.in/iitr
@@ -1,0 +1,1 @@
+Indian Institute of Technology, Roorkee

--- a/lib/domains/ernet.in/iitr
+++ b/lib/domains/ernet.in/iitr
@@ -1,0 +1,1 @@
+Indian Institute Of Technology, Roorkee


### PR DESCRIPTION
Our institute uses 2 domains: iitr.ac.in for web, and iitr.ernet.in for email. Added both in the pull request.
