### PR TITLE
Remove edu.cn from whitelisted TLDs

### DIFF
--- a/lib/swot.rb
+++ b/lib/swot.rb
@@ -53,7 +53,6 @@ module Swot
     'edu.bs',
     'edu.bt',
     'edu.bz',
-    'edu.cn',
     'edu.co',
     'edu.cu',
     'edu.do',


### PR DESCRIPTION
There are a number of non-academic domains hosted on edu.cn, so we shouldn't include it by default.
