### PR TITLE
Add 'proper' University of Manchester address format

### DIFF
--- a/lib/domains/ac.uk/manchester
+++ b/lib/domains/ac.uk/manchester
@@ -1,0 +1,1 @@
+University of Manchester


### PR DESCRIPTION
The current man.ac.uk may work, but the canonical form (i.e the one we are all told to use, put in directories, etc) is manchester.ac.uk.
