### PR TITLE
Refactor #get_institution_name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: ruby
+rvm:
+  - 1.9.3
+  - 2.0.0

--- a/test/test_swot.rb
+++ b/test/test_swot.rb
@@ -48,6 +48,10 @@ class TestEmail < Test::Unit::TestCase
     assert_equal Swot::get_institution_name('lreilly@cs.strath.ac.uk'), "University of Strathclyde"
   end
 
+  should "returns nil when institution invalid" do
+    assert_equal Swot::get_institution_name('foo@shop.com'), nil
+  end
+
   should "test aliased methods" do
     assert_equal Swot::academic?('stanford.edu'), true
     assert_equal Swot::school_name('lreilly@cs.strath.ac.uk'), "University of Strathclyde"


### PR DESCRIPTION
Hi Lee,

This Pull Request suggests a few refactors to DRY the codebase. Basically, `#get_institution_name` now uses `#get_domain`.  

I hope you like it, and thanks for swot!
Simeon
- Refactor `#get_institution_name` to use `#get_domain`
- Define `#get_path` to get file path from domain
  - `#match_academic_domain?` and `#name_from_academic_domain` use `#get_path`
- Strip input `text` within `#get_domain`
- Replace `File.open` with `File.read` in `#name_from_academic_domain`
  - Be more concise
  - Ensure file is closed
- Add Travis CI
  - Requires [activating a service hook](http://about.travis-ci.org/docs/user/getting-started/#Step-two%3A-Activate-GitHub-Service-Hook)
