### PR TITLE
Swot::get_institution_name reads UTF-8 files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Swot :apple:
 
+[![Build Status](https://api.travis-ci.org/leereilly/swot.png)](https://travis-ci.org/leerilly/swot)
+
 If you have a product or service and offer **academic discounts**, there's a good chance there's some manual component to the approval process. Perhaps `.edu` email addresses are automatically approved because, for the most part at least, they're associated with American post-secondary educational institutions. Perhaps `.ac.uk` email addresses are automatically approved because they're guaranteed to belong to British universities and colleges. Unfortunately, not every country has an education-specific TLD (Top Level Domain) and plenty of schools use `.com` or `.net`.
 
 Swot is a community-driven or crowdsourced library for verifying that domain names and email addresses are tied to a legitimate university of college - more specifically, an academic institution providing higher education in tertiary, quaternary or any other kind of post-secondary education in any country in the world.

--- a/lib/swot.rb
+++ b/lib/swot.rb
@@ -173,7 +173,7 @@ module Swot
     # Return the institution name, or nil if not found.
     def name_from_academic_domain(domain)
       begin
-        File.read(get_path(domain), :mode => "rb").strip
+        File.read(get_path(domain), :mode => "rb", :external_encoding => "UTF-8").strip
       rescue
         return nil
       end

--- a/test/test_swot.rb
+++ b/test/test_swot.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 require 'helper'
 
 class TestEmail < Test::Unit::TestCase
@@ -46,6 +47,7 @@ class TestEmail < Test::Unit::TestCase
 
   should "returns name of valid institution" do
     assert_equal Swot::get_institution_name('lreilly@cs.strath.ac.uk'), "University of Strathclyde"
+    assert_equal Swot::get_institution_name('lreilly@fadi.at'), "BRG Fadingerstraße Linz, Austria"
   end
 
   should "returns nil when institution invalid" do


### PR DESCRIPTION
- Add magic encoding comment to test_swot.rb, so Ruby knows its UTF-8
- Add assertion for testing a valid email returns a UTF-8 string
- Add Travis CI build status badge to README
