### PR TITLE
Gem bump

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 Gemfile.lock
 *.gem
+.bundle

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,6 @@ group :development do
   gem "rake", "~> 10.0.4"
   gem "shoulda", ">= 0"
   gem "rdoc", "~> 3.12"
-  gem "bundler", "~> 1.3.5"
+  gem "bundler", "~> 1.5.0"
   gem "jeweler", "~> 1.8.3"
 end

--- a/lib/swot.rb
+++ b/lib/swot.rb
@@ -1,7 +1,7 @@
 require 'public_suffix'
 
 module Swot
-  VERSION = "0.1.0"
+  VERSION = "0.3.0"
 
   # These top-level domains are guaranteed to be academic institutions.
   ACADEMIC_TLDS = {

--- a/swot.gemspec
+++ b/swot.gemspec
@@ -5,11 +5,11 @@
 
 Gem::Specification.new do |s|
   s.name = "swot"
-  s.version = "0.2.13"
+  s.version = "0.3.0"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Lee Reilly"]
-  s.date = "2013-05-28"
+  s.date = "2014-03-31"
   s.description = "email helpers"
   s.email = "lee@leereilly.net"
   s.extra_rdoc_files = [
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.files = [
     ".document",
     ".ruby-version",
+    ".travis.yml",
     "CONTRIBUTING.md",
     "Gemfile",
     "LICENSE.txt",
@@ -331,6 +332,7 @@ Gem::Specification.new do |s|
     "lib/domains/ac.il/weizmann",
     "lib/domains/ac.il/wgalil",
     "lib/domains/ac.il/yvc",
+    "lib/domains/ac.in/becs",
     "lib/domains/ac.in/bitmesra",
     "lib/domains/ac.in/bits-pilani",
     "lib/domains/ac.in/daiict",
@@ -1257,6 +1259,7 @@ Gem::Specification.new do |s|
     "lib/domains/ac.uk/soas",
     "lib/domains/ac.uk/solent",
     "lib/domains/ac.uk/soton",
+    "lib/domains/ac.uk/southwales",
     "lib/domains/ac.uk/ssees",
     "lib/domains/ac.uk/st-and",
     "lib/domains/ac.uk/st-patricks",
@@ -1355,6 +1358,7 @@ Gem::Specification.new do |s|
     "lib/domains/asso.fr/essca",
     "lib/domains/asso.fr/fupl",
     "lib/domains/asso.fr/ict-toulouse",
+    "lib/domains/at/fadi",
     "lib/domains/at/fh-burgenland",
     "lib/domains/at/fh-hagenberg",
     "lib/domains/at/fh-joanneum",
@@ -1672,6 +1676,7 @@ Gem::Specification.new do |s|
     "lib/domains/ca/rrc",
     "lib/domains/ca/ryerson",
     "lib/domains/ca/sait",
+    "lib/domains/ca/saultcollege",
     "lib/domains/ca/sfu",
     "lib/domains/ca/stfx",
     "lib/domains/ca/stmarys",
@@ -6331,6 +6336,7 @@ Gem::Specification.new do |s|
     "lib/domains/fr/essec",
     "lib/domains/fr/estp",
     "lib/domains/fr/eudil",
+    "lib/domains/fr/eurecom",
     "lib/domains/fr/hec",
     "lib/domains/fr/hei",
     "lib/domains/fr/icam",
@@ -7695,25 +7701,25 @@ Gem::Specification.new do |s|
   s.homepage = "http://github.com/leereilly/swot"
   s.licenses = ["MIT"]
   s.require_paths = ["lib"]
-  s.rubygems_version = "1.8.23"
+  s.rubygems_version = "2.0.14"
   s.summary = "email helpers"
 
   if s.respond_to? :specification_version then
-    s.specification_version = 3
+    s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<public_suffix>, [">= 0"])
       s.add_development_dependency(%q<rake>, ["~> 10.0.4"])
       s.add_development_dependency(%q<shoulda>, [">= 0"])
       s.add_development_dependency(%q<rdoc>, ["~> 3.12"])
-      s.add_development_dependency(%q<bundler>, ["~> 1.2.1"])
+      s.add_development_dependency(%q<bundler>, ["~> 1.5.0"])
       s.add_development_dependency(%q<jeweler>, ["~> 1.8.3"])
     else
       s.add_dependency(%q<public_suffix>, [">= 0"])
       s.add_dependency(%q<rake>, ["~> 10.0.4"])
       s.add_dependency(%q<shoulda>, [">= 0"])
       s.add_dependency(%q<rdoc>, ["~> 3.12"])
-      s.add_dependency(%q<bundler>, ["~> 1.2.1"])
+      s.add_dependency(%q<bundler>, ["~> 1.5.0"])
       s.add_dependency(%q<jeweler>, ["~> 1.8.3"])
     end
   else
@@ -7721,7 +7727,7 @@ Gem::Specification.new do |s|
     s.add_dependency(%q<rake>, ["~> 10.0.4"])
     s.add_dependency(%q<shoulda>, [">= 0"])
     s.add_dependency(%q<rdoc>, ["~> 3.12"])
-    s.add_dependency(%q<bundler>, ["~> 1.2.1"])
+    s.add_dependency(%q<bundler>, ["~> 1.5.0"])
     s.add_dependency(%q<jeweler>, ["~> 1.8.3"])
   end
 end


### PR DESCRIPTION
Fixes #44 with a friendly :smile:. Just needs to be published to rubygems.
## [Changelog](https://github.com/leereilly/swot/compare/v0.2.13...master):
- Added becs.ac.in (#30)
- Add file for BRG Fadingerstraße, Linz, Austria (#31)
- Refactor `#get_institution_name` to use `#get_domain` (#32)
- Bump Bundler
- `Swot::get_institution_name` reads UTF-8 files (#33)
- Documentation improvements (#34, #35)
- Added the University of South Wales (#36)
- Domain blacklist (#39)
- Create eurecom (#43)

/cc @afeld, @konklone
