### PR TITLE
Adds UCLive.ac.nz

### DIFF
--- a/lib/domains/ac.nz/uclive
+++ b/lib/domains/ac.nz/uclive
@@ -1,0 +1,1 @@
+University of Canterbury


### PR DESCRIPTION
This is the domain used for undergrad email addresses at the University
of Canterbury, Christchurch, New Zealand
