### PR TITLE
pwr.wroc.pl: Correct the university name

### DIFF
--- a/lib/domains/wroc.pl/pwr
+++ b/lib/domains/wroc.pl/pwr
@@ -1,2 +1,1 @@
-Technical University of Wroclaw
-Technical University of Wroclaw
+Wrocław University of Technology


### PR DESCRIPTION
Here’s the [English version of the official website](http://www.portal.pwr.edu.pl/index,242.dhtml) that confirms it.
