### PR TITLE
Change to Toulouse Business School's new domain

### DIFF
--- a/lib/domains/fr/esc-toulouse
+++ b/lib/domains/fr/esc-toulouse
@@ -1,0 +1,1 @@
+Ecole Supérieure de Commerce de Toulouse


### PR DESCRIPTION
Hi !

École Supérieure de Commerce de Toulouse is now Toulouse Business School. The domain for students' emails has changed from [esc-toulouse.fr](http://esc-toulouse.fr) to [toulouse-bs.org](http://toulouse-bs.org).

Hope I've done everything right ;-)

P.S. : [toulouse-bs.org](http://toulouse-bs.org) will redirect to [toulouse-bs.fr](http://toulouse-bs.fr) which is normal because the .fr TLD is for the school's staff. Only students have a .org email address.
