### PR TITLE
Add sydney.edu.au domain

### DIFF
--- a/lib/domains/au/edu/sydney.txt
+++ b/lib/domains/au/edu/sydney.txt
@@ -1,0 +1,1 @@
+University of Sydney


### PR DESCRIPTION
This is a new domain of University of Sydney. The old usyd.edu.au is still in use as well.
