### PR TITLE
updated the name for fh-zwickau.de

### DIFF
--- a/lib/domains/de/fh-zwickau.txt
+++ b/lib/domains/de/fh-zwickau.txt
@@ -1,1 +1,1 @@
-Westsächsische Hochschule Zwickau (FH)
+Westsächsische Hochschule Zwickau


### PR DESCRIPTION
(FH) has since been dropped from the name, as it is no longer required in Germany.
