### PR TITLE
Create hs-ludwigshafen.txt

### DIFF
--- a/lib/domains/de/hs-ludwigshafen.txt
+++ b/lib/domains/de/hs-ludwigshafen.txt
@@ -1,0 +1,1 @@
+Hochschule Ludwigshafen am Rhein


### PR DESCRIPTION
FH Ludwigshafen changed name to HS Ludwigshafen (fh-ludwigshafen.de to hs-ludwigshafen.de).
fh-ludwigshafen.de is still valid.
