### PR TITLE
Adds  the new domain for Universidade de Lisboa.

### DIFF
--- a/lib/domains/pt/ulisboa.txt
+++ b/lib/domains/pt/ulisboa.txt
@@ -1,0 +1,1 @@
+Universidade de Lisboa


### PR DESCRIPTION
Universidade de Lisboa (UL) recently merged with Universidade Técnica de Lisboa (UTL), adopting the name Universidade de Lisboa (ULisboa).
I kept both UL and UTL files because there are still some colleges that still provide their e-mails with the old domains.
