### PR TITLE
fix for invalid domains

### DIFF
--- a/lib/swot.rb
+++ b/lib/swot.rb
@@ -32,7 +32,7 @@ class Swot < NaughtyOrNice
   # Returns true if the domain name belongs to an academic institution;
   #  false otherwise.
   def valid?
-    if domain.nil?
+    if domain.nil? || domain_parts.nil?
       false
     elsif BLACKLIST.any? { |d| domain =~ /(\A|\.)#{Regexp.escape(d)}\z/ }
       false

--- a/test/test_swot.rb
+++ b/test/test_swot.rb
@@ -75,4 +75,8 @@ describe Swot do
     Swot::is_academic? ".com"
     assert_equal false, Swot::is_academic?(".com")
   end
+
+  it "does not err on invalid domains" do
+    assert_equal false, Swot::is_academic?("foo@bar.invalid")
+  end
 end


### PR DESCRIPTION
Prevent errors when domains appear valid, but are actually invalid via PublicSuffix (e.g., `foo@domain.invalid`).
