### PR TITLE
Add more domains to the blacklist

### DIFF
--- a/lib/swot.rb
+++ b/lib/swot.rb
@@ -11,6 +11,9 @@ class Swot < NaughtyOrNice
   BLACKLIST = %w(
     si.edu
     america.edu
+    californiacolleges.edu
+    australia.edu
+    cet.edu
   ).freeze
 
   class << self


### PR DESCRIPTION
This blacklists some additional domains that allow non-student users to sign up for otherwise-valid `.edu` email addresses and can register as a false positive when Swot is used for verification.

/cc @johndbritton 
