### PR TITLE
Create ulatina.txt

### DIFF
--- a/lib/domains/net/ulatina.txt
+++ b/lib/domains/net/ulatina.txt
@@ -1,0 +1,1 @@
+Universidad Latina


### PR DESCRIPTION
Universidad Latina (Laureate Universities network) is incorrectly listed under cr/ac (ac.cr) which while corresponds to the website does not reflects students emails which are provisioned as firstname.lastname@ulatina.net