### PR TITLE
File.exists? is depricated

### DIFF
--- a/lib/swot.rb
+++ b/lib/swot.rb
@@ -64,7 +64,7 @@ class Swot < NaughtyOrNice
   # Returns true if the domain name belongs to a known academic institution;
   #  false otherwise.
   def academic_domain?
-    @academic_domain ||= File.exists?(file_path)
+    @academic_domain ||= File.exist?(file_path)
   end
 
   private


### PR DESCRIPTION
http://www.ruby-doc.org/core-2.1.3/File.html#method-c-exist-3F

Source: `rb_warning("%sexists? is a deprecated name, use %sexist? instead", s, s);`