### PR TITLE
Added Academy of Interactive Entertainment (AIE)

### DIFF
--- a/lib/domains/au/edu/aie.txt
+++ b/lib/domains/au/edu/aie.txt
@@ -1,0 +1,1 @@
+Academy of Interactive Entertainment


### PR DESCRIPTION
I attend the Academy of Interactive Entertainment which has a website at http://www.aie.edu.au/.  

In terms of e-mails, staff bear the ```aie.edu.au``` domain while students bear the ```students.aie.edu.au``` domain. Seeing as swot does not make any distinction between staff or student domains, I added only the former.