### PR TITLE
Create whitgiftschool.txt

### DIFF
--- a/lib/domains/net/whitgiftschool.txt
+++ b/lib/domains/net/whitgiftschool.txt
@@ -1,0 +1,1 @@
+Whitgift School

--- a/lib/domains/uk/co/whitgiftschool.txt
+++ b/lib/domains/uk/co/whitgiftschool.txt
@@ -1,0 +1,1 @@
+Whitgift School

--- a/lib/domains/uk/co/whitgiftschool.txt
+++ b/lib/domains/uk/co/whitgiftschool.txt
@@ -1,1 +1,0 @@
-Whitgift School


### PR DESCRIPTION
Note: @whitgiftschool.net is the domain for Whitgift School students. Whitgift's website is http://whitgift.co.uk/, but @whitgift.co.uk is strictly reserved for staff.