### PR TITLE
gso-koeln

### DIFF
--- a/lib/domains/de/gso-koeln
+++ b/lib/domains/de/gso-koeln
@@ -1,0 +1,1 @@
+Georg-Simon-Ohm-Berufskolleg in Köln


### PR DESCRIPTION
Georg-Simon-Ohm-Berufskolleg in Köln