### PR TITLE
Create chibakoudai

### DIFF
--- a/lib/domains/jp/chibakoudai
+++ b/lib/domains/jp/chibakoudai
@@ -1,0 +1,1 @@
+Chiba Institute of Technology


### PR DESCRIPTION
it-chiba.ac.jp is old mail-address.
Student use ～@s.chibakoudai.jp now.
Please add this.