### PR TITLE
Add swot-clj port to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,3 +108,4 @@ If you verified this by visiting all of the websites, how long did it take you? 
 * [gman](https://github.com/benbalter/gman) - like swot, but for government emails
 * [swotphp](https://github.com/mdwheele/swotphp) - PHP port of Swot
 * [swot-js](https://github.com/theotow/swot-js) - JS port of Swot
+* [swot-clj](https://github.com/ipavl/swot-clj) - Clojure port of Swot


### PR DESCRIPTION
I ported Swot to Clojure, and it passes Swot's test cases so it should be ready for use now.