### PR TITLE
Create hhek.txt : Added vocational school heinrich-hertz-europakolleg der bundestadt bonn

### DIFF
--- a/lib/domains/de/bonn/hhek.txt
+++ b/lib/domains/de/bonn/hhek.txt
@@ -1,0 +1,1 @@
+heinrich-hertz-europakolleg der bundesstadt bonn (vocational school)


### PR DESCRIPTION

  heinrich-hertz europakolleg der bundesstadt bonn
  berufskolleg mit beruflichem gymnasium
  (vocational school and vocational secondary school)
  Herseler Str. 1
  53117 Bonn
  Deutschland (Germany)
  http://www.hhek.bonn.de