### PR TITLE
Add Systems Security Laboratory, University of Piraeus

### DIFF
--- a/lib/domains/gr/ssl-unipi.txt
+++ b/lib/domains/gr/ssl-unipi.txt
@@ -1,0 +1,1 @@
+Systems Security Laboratory, University of Piraeus


### PR DESCRIPTION
Hi, 
I would like to add the Systems Security Laboratory of the University of Piraeus (www.ssl-unipi.gr) to the college list. 
Thanks!