### PR TITLE
Create lgflmail.txt

### DIFF
--- a/lib/domains/org/lgflmail.txt
+++ b/lib/domains/org/lgflmail.txt
@@ -1,0 +1,1 @@
+London Grid For Learning


### PR DESCRIPTION
The LGfL Trust is a consortium of the London local authorities and 2.500 schools working together to provide extensive and cost effective ICT services, particularly for school broadband services. By working together schools save millions of pounds a year (about £35,000 per primary and £135,000 per secondary school) compared to schools purchasing the same services individually. For a full list of LGfL services you can download our services guide. You can find our more about our partners by looking through our supplier list.
 
To undertake collective procurements and other business, the consortium established a non-profit company and charitable trust in 2001. The day-to-day operation of the company is the responsibility of the Chief Executive who is accountable to the Executive Board and other boards. (See Steering Groups​)
 
The LGfL is a member of the NEN Education Network to ensure that all schools, colleges and universities are connected through a single backbone enabling a high quality e-learning experience in a safe and secure networked environment.
- See more at: http://www.lgfl.net/about/Pages/default.aspx#sthash.fBzuUmYN.dpuf