### PR TITLE
Create fclive.nl

### DIFF
--- a/lib/domains/nl/fclive.nl
+++ b/lib/domains/nl/fclive.nl
@@ -1,0 +1,1 @@
+Friesland College


### PR DESCRIPTION
Email domain for students of Friesland College (frieslandcollege.nl)