### PR TITLE
File validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,6 @@ language: ruby
 rvm:
   - 2.0.0
   - 2.2.0
+script:
+  - bundle exec rake test
+  - bundle exec rake validate_domain_files

--- a/Gemfile
+++ b/Gemfile
@@ -10,4 +10,5 @@ group :development do
   gem "bundler", "~> 1.5"
   gem "jeweler", "~> 1.8"
   gem "minitest"
+  gem "pry"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -68,6 +68,20 @@ task :add, :sld, :tld, :name do |t, args|
   end
 end
 
+task :check_files do
+  require './lib/swot'
+  all_schools = {}
+  swot_data_path = Pathname.new(Swot.domains_path)
+  Pathname.glob(swot_data_path.join('**/*.txt')) do |path|
+    path_dir, file = path.relative_path_from(swot_data_path).split
+    backwards_path = path_dir.to_s.split('/').push(file.basename('.txt').to_s)
+    unsanitized_school_name = path.readlines.first
+    unless unsanitized_school_name.valid_encoding?
+      puts "Invalid encoding for #{unsanitized_school_name} in #{path}"
+    end
+  end
+end
+
 task :quackit_import do
   require 'nokogiri'
   require 'open-uri'

--- a/lib/domains/br/unopar.txt
+++ b/lib/domains/br/unopar.txt
@@ -1,1 +1,1 @@
-Universidade Norte do Paran·
+Universidade Norte do Paran√°

--- a/lib/domains/fi/hamk.txt
+++ b/lib/domains/fi/hamk.txt
@@ -1,1 +1,1 @@
-HAMK University of Applied Sciences - Hämeen Ammattikorkeakoulu
+HAMK University of Applied Sciences - HÃ¤meen Ammattikorkeakoulu

--- a/lib/domains/fr/viacesi.txt
+++ b/lib/domains/fr/viacesi.txt
@@ -1,1 +1,1 @@
-CESI Enseignement Supérieur et Formation Professionnelle
+CESI Enseignement SupÃ©rieur et Formation Professionnelle

--- a/lib/swot.rb
+++ b/lib/swot.rb
@@ -82,8 +82,6 @@ class Swot < NaughtyOrNice
     @academic_domain ||= File.exist?(file_path)
   end
 
-  private
-
   def file_path
     @file_path ||= File.join(Swot::domains_path, domain_parts.domain.to_s.split(".").reverse) + ".txt"
   end


### PR DESCRIPTION
Adding a rake task to validate domain files when building on travis. The validate_domain_files task checks to see if the files are valid, and have school_names without encoding errors. This should give us some good feedback for incoming domain additions.

Below is the output from running the task on c952f57ca070c. A number of the domain file entries are not being reported as valid. Any ideas what would be causing this?

References #671

```
$ bundle exec rake validate_domain_files
Error: Some domains are invalid:
["Swot reporting domain as invalid: htl.moedling.at",
 "Swot reporting domain as invalid: htl.rennweg.at",
 "Swot reporting domain as invalid: www.nt.gov.au",
 "Swot reporting domain as invalid: unsa.ba",
 "No school name set in /Users/chris/src/projects/github/swot/lib/domains/br/com/unitau.txt",
 "Swot reporting domain as invalid: ime.eb.br",
 "Invalid encoding in /Users/chris/src/projects/github/swot/lib/domains/ca/qc/cstj.txt",
 "Swot reporting domain as invalid: master.hes-so.ch",
 "Swot reporting domain as invalid: mail.gxu.cn",
 "Swot reporting domain as invalid: hhek.bonn.de",
 "Swot reporting domain as invalid: mmbbs.eduplaza.de",
 "Swot reporting domain as invalid: californiacolleges.edu",
 "Swot reporting domain as invalid: student.42.fr",
 "Swot reporting domain as invalid: iisc.ernet.in",
 "Swot reporting domain as invalid: iitd.ernet.in",
 "Swot reporting domain as invalid: iitg.ernet.in",
 "Swot reporting domain as invalid: iitkgp.ernet.in",
 "Swot reporting domain as invalid: iitr.ernet.in",
 "Swot reporting domain as invalid: ds.units.it",
 "Swot reporting domain as invalid: usafa.af.mil",
 "Swot reporting domain as invalid: nps.navy.mil",
 "Swot reporting domain as invalid: live.emvs.net",
 "Swot reporting domain as invalid: student.funaab.edu.ng",
 "Swot reporting domain as invalid: lautech.student.edu.ng",
 "Swot reporting domain as invalid: leerling.hetccc.nl",
 "Swot reporting domain as invalid: student.inholland.nl",
 "Swot reporting domain as invalid: student.rocva.nl",
 "Swot reporting domain as invalid: student.scalda.nl",
 "Swot reporting domain as invalid: ap.siedlce.pl",
 "Swot reporting domain as invalid: www.una.py",
 "Swot reporting domain as invalid: online.muiv.ru",
 "Swot reporting domain as invalid: edu.tm",
 "Swot reporting domain as invalid: www.luz.ve",
 "Swot reporting domain as invalid: www.ucv.ve",
 "Swot reporting domain as invalid: www.ula.ve",
 "Swot reporting domain as invalid: cg.ac.yu"]
rake aborted!
```