### PR TITLE
Added Mathematics Society of The University of Waterloo

### DIFF
--- a/lib/domains/ca/uwaterloo/mathsoc.txt
+++ b/lib/domains/ca/uwaterloo/mathsoc.txt
@@ -1,0 +1,1 @@
+Mathematics Society of The University of Waterloo


### PR DESCRIPTION
The Mathematics Society of The University of Waterloo is a society
for undergraduate math students at the school.

Students within the society have email addresses at the
mathsoc.uwaterloo.ca subdomain.

cc @DrTeePot, President of the UWaterloo Mathematics Society.