### PR TITLE
Added Student Domain for Belfast Metropolitan College

### DIFF
--- a/lib/domains/uk/ac/belfastmet/student.txt
+++ b/lib/domains/uk/ac/belfastmet/student.txt
@@ -1,0 +1,1 @@
+Belfast Metropolitan College


### PR DESCRIPTION
Belfast Metropolitan College is a Further Education College in Belfast, Northern Ireland. They provide a variety of further education courses, including Foundation Degrees and BTEC Level 5 courses - partial equivalents to university degrees.

Student email addresses assigned at the Belfast metropolitan college are from the student.belfastmet.ac.uk subdomain

Staff are assigned emails from the  belfastmet.ac.uk domain

I have added the file in accordance with the policy in the README; in that only students will be verfied

File structure based upon that seen [here](https://github.com/leereilly/swot/tree/master/lib/domains/nl)