### PR TITLE
Added Kaunas university of technology to .edu domains (ktu.edu)

### DIFF
--- a/lib/domains/edu/ktu.txt
+++ b/lib/domains/edu/ktu.txt
@@ -1,0 +1,1 @@
+Kauno technologijos universitetas


### PR DESCRIPTION
Kaunas university of technology quite recently started using [ktu.edu](http://www.ktu.edu) (newer) as well as [ktu.lt](http://www.ktu.lt) (older) domain name.