### PR TITLE
Add uchceu domain

### DIFF
--- a/lib/domains/es/ceu.txt
+++ b/lib/domains/es/ceu.txt
@@ -1,2 +1,1 @@
-Universidad Cardenal Herrera-CEU
 Universidad de San Pablo CEU

--- a/lib/domains/es/uchceu.txt
+++ b/lib/domains/es/uchceu.txt
@@ -1,0 +1,1 @@
+Universidad Cardenal Herrera-CEU


### PR DESCRIPTION
Moved "Universidad Cardenal Herrera-CEU" to their new domain: uchceu, see https://www.uchceu.es/