### PR TITLE
Add the Royal Grammar School

### DIFF
--- a/lib/domains/uk/co/rgs-guildford.txt
+++ b/lib/domains/uk/co/rgs-guildford.txt
@@ -1,0 +1,1 @@
+RGS Guildford


### PR DESCRIPTION
Hi,

This is a second attempt at a commit, as my previous one was classed as not a secondary school.
I can confirm it is most definitely a secondary school, running from year 7 to year 13. (it includes a sixth form college) I have just taken my AS-level exams there.

>The RGS is a dynamic and vibrant independent day school for boys aged 11 to 18.
>- http://www.rgs-guildford.co.uk/364/about-the-rgs/overview

Thanks,
Rob (lower 6th former @ RGS)