### PR TITLE
Create demokritos.txt

### DIFF
--- a/lib/domains/gr/demokritos.txt
+++ b/lib/domains/gr/demokritos.txt
@@ -1,0 +1,1 @@
+NCSR Demokritos


### PR DESCRIPTION
Please add the NCSR Demokritos in Greece. Demokritos is a public research organization of the Greek Ministry of Education.