### PR TITLE
Use naughty or nice 2.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "http://rubygems.org"
 
 gem 'public_suffix'
-gem 'naughty_or_nice', "~> 1.0"
+gem 'naughty_or_nice', "~> 2.0"
 
 group :development do
   gem "nokogiri", "~> 1.5"

--- a/lib/swot.rb
+++ b/lib/swot.rb
@@ -52,11 +52,11 @@ class Swot
   # Returns true if the domain name belongs to an academic institution;
   #  false otherwise.
   def valid?
-    if domain.nil? || domain_parts.nil?
+    if domain.nil?
       false
-    elsif BLACKLIST.any? { |d| domain =~ /(\A|\.)#{Regexp.escape(d)}\z/ }
+    elsif BLACKLIST.any? { |d| domain.to_s =~ /(\A|\.)#{Regexp.escape(d)}\z/ }
       false
-    elsif ACADEMIC_TLDS.include?(domain_parts.tld)
+    elsif ACADEMIC_TLDS.include?(domain.tld)
       true
     elsif academic_domain?
       true
@@ -87,6 +87,6 @@ class Swot
   private
 
   def file_path
-    @file_path ||= File.join(Swot::domains_path, domain_parts.domain.to_s.split(".").reverse) + ".txt"
+    @file_path ||= File.join(Swot::domains_path, domain.domain.to_s.split(".").reverse) + ".txt"
   end
 end

--- a/lib/swot.rb
+++ b/lib/swot.rb
@@ -54,7 +54,7 @@ class Swot
   def valid?
     if domain.nil?
       false
-    elsif BLACKLIST.any? { |d| domain.to_s =~ /(\A|\.)#{Regexp.escape(d)}\z/ }
+    elsif BLACKLIST.any? { |d| to_s =~ /(\A|\.)#{Regexp.escape(d)}\z/ }
       false
     elsif ACADEMIC_TLDS.include?(domain.tld)
       true

--- a/lib/swot/collection_methods.rb
+++ b/lib/swot/collection_methods.rb
@@ -4,7 +4,7 @@ module SwotCollectionMethods
 
   # Returns an array of domain strings.
   def all_domains
-    each_domain.map(&:domain)
+    each_domain.map(&:to_s)
   end
 
   # Yields a Swot instance for every domain under lib/domains. Does not

--- a/swot.gemspec
+++ b/swot.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Lee Reilly"]
-  s.date = "2015-06-30"
+  s.date = "2015-07-09"
   s.description = "Identify email addresses or domains names that belong to colleges or universities. Help automate the process of approving or rejecting academic discounts."
   s.email = "lee@leereilly.net"
   s.extra_rdoc_files = [
@@ -1544,6 +1544,7 @@ Gem::Specification.new do |s|
     "lib/domains/cz/vsfs.txt",
     "lib/domains/cz/vslib.txt",
     "lib/domains/cz/vsp.txt",
+    "lib/domains/cz/vspj.txt",
     "lib/domains/cz/vutbr.txt",
     "lib/domains/cz/zcu.txt",
     "lib/domains/de/akad.txt",
@@ -1726,6 +1727,7 @@ Gem::Specification.new do |s|
     "lib/domains/de/hs-magdeburg.txt",
     "lib/domains/de/hs-mannheim.txt",
     "lib/domains/de/hs-mittweida.txt",
+    "lib/domains/de/hs-neu-ulm.txt",
     "lib/domains/de/hs-offenburg.txt",
     "lib/domains/de/hs-osnabrueck.txt",
     "lib/domains/de/hs-owl.txt",
@@ -1892,6 +1894,7 @@ Gem::Specification.new do |s|
     "lib/domains/de/unibw.txt",
     "lib/domains/de/uos.txt",
     "lib/domains/de/upb.txt",
+    "lib/domains/de/vwa-gruppe-net.txt",
     "lib/domains/de/w-hs.txt",
     "lib/domains/de/wak-sh.txt",
     "lib/domains/de/whu-koblenz.txt",
@@ -4743,6 +4746,7 @@ Gem::Specification.new do |s|
     "lib/domains/in/ac/unipune.txt",
     "lib/domains/in/ac/vit.txt",
     "lib/domains/in/ac/vvpedulink.txt",
+    "lib/domains/in/aryacollege.txt",
     "lib/domains/in/edu/gtu.txt",
     "lib/domains/in/edu/karunya.txt",
     "lib/domains/in/edu/skpit.txt",
@@ -5386,6 +5390,7 @@ Gem::Specification.new do |s|
     "lib/domains/jp/ac/u-keiai.txt",
     "lib/domains/jp/ac/u-tokai.txt",
     "lib/domains/jp/ac/u-tokyo.txt",
+    "lib/domains/jp/ac/ynu.txt",
     "lib/domains/jp/chibakoudai.txt",
     "lib/domains/jp/co/termnet.txt",
     "lib/domains/jp/keio.txt",
@@ -5395,6 +5400,7 @@ Gem::Specification.new do |s|
     "lib/domains/jp/sendai-nct.txt",
     "lib/domains/jp/senshu-u.txt",
     "lib/domains/jp/waseda.txt",
+    "lib/domains/jp/ynu.txt",
     "lib/domains/ke/ac/anu.txt",
     "lib/domains/ke/ac/egerton.txt",
     "lib/domains/ke/ac/iu.txt",
@@ -6096,6 +6102,7 @@ Gem::Specification.new do |s|
     "lib/domains/net/ubuea.txt",
     "lib/domains/net/ucasal.txt",
     "lib/domains/net/ulatina.txt",
+    "lib/domains/net/unesc.txt",
     "lib/domains/net/univ-mngb.txt",
     "lib/domains/net/universityofsomalia.txt",
     "lib/domains/net/uoit.txt",
@@ -6273,6 +6280,7 @@ Gem::Specification.new do |s|
     "lib/domains/org/hsrw.txt",
     "lib/domains/org/icu-edu.txt",
     "lib/domains/org/internationaluniversity-schoolofmedicine.txt",
+    "lib/domains/org/ipeindia.txt",
     "lib/domains/org/ipiaget.txt",
     "lib/domains/org/islahonline.txt",
     "lib/domains/org/khazar.txt",
@@ -7160,6 +7168,7 @@ Gem::Specification.new do |s|
     "lib/domains/ru/vstu.txt",
     "lib/domains/ru/vsu.txt",
     "lib/domains/ru/vvsu.txt",
+    "lib/domains/ru/vyatsu.txt",
     "lib/domains/ru/wsnet.txt",
     "lib/domains/ru/yar.txt",
     "lib/domains/ru/yaroslavl/rgata.txt",
@@ -8074,7 +8083,7 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<public_suffix>, [">= 0"])
-      s.add_runtime_dependency(%q<naughty_or_nice>, ["~> 1.0"])
+      s.add_runtime_dependency(%q<naughty_or_nice>, ["~> 2.0"])
       s.add_development_dependency(%q<nokogiri>, ["~> 1.5"])
       s.add_development_dependency(%q<rake>, ["~> 10.0"])
       s.add_development_dependency(%q<rdoc>, ["~> 3.12"])
@@ -8083,7 +8092,7 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<minitest>, ["~> 4.7.5"])
     else
       s.add_dependency(%q<public_suffix>, [">= 0"])
-      s.add_dependency(%q<naughty_or_nice>, ["~> 1.0"])
+      s.add_dependency(%q<naughty_or_nice>, ["~> 2.0"])
       s.add_dependency(%q<nokogiri>, ["~> 1.5"])
       s.add_dependency(%q<rake>, ["~> 10.0"])
       s.add_dependency(%q<rdoc>, ["~> 3.12"])
@@ -8093,7 +8102,7 @@ Gem::Specification.new do |s|
     end
   else
     s.add_dependency(%q<public_suffix>, [">= 0"])
-    s.add_dependency(%q<naughty_or_nice>, ["~> 1.0"])
+    s.add_dependency(%q<naughty_or_nice>, ["~> 2.0"])
     s.add_dependency(%q<nokogiri>, ["~> 1.5"])
     s.add_dependency(%q<rake>, ["~> 10.0"])
     s.add_dependency(%q<rdoc>, ["~> 3.12"])

--- a/test/test_collection_methods.rb
+++ b/test/test_collection_methods.rb
@@ -37,8 +37,8 @@ describe 'SwotCollectionMethods' do
       Swot.each_domain { |d| domains << d }
       assert_equal domains.size, 2
       assert_equal true, domains.all?{ |d| d.is_a? Swot }
-      assert_includes domains.map(&:domain), "students.texas.edu"
-      assert_includes domains.map(&:domain), "mit.edu"
+      assert_includes domains.map(&:to_s), "students.texas.edu"
+      assert_includes domains.map(&:to_s), "mit.edu"
     end
   end
 end


### PR DESCRIPTION
Fresh off the heels of [Naughty or Nice 1.0.0](https://github.com/leereilly/swot/pull/874), Naughty or Nice 2.0.0 is here!

There's not all that much too exciting, mostly a semantic change. Now [the `#domain` method returns a `PublicSuffix::Domain`, instance, rather than the domain string](https://github.com/benbalter/naughty_or_nice/pull/4).

To access the domain string, you'll want to use `to_s` or `domain.to_s`.

This allows us to store and pass the domain around internally as a `PublicSuffix::Domain` object, rather than potentially reparsing it back and forth from object to string, for a small performance improvement.