### PR TITLE
Add Warren County Technical School

### DIFF
--- a/lib/domains/org/wctech.txt
+++ b/lib/domains/org/wctech.txt
@@ -1,0 +1,1 @@
+Warren County Technical School


### PR DESCRIPTION
Warren County Technical School is a vocational technical school in Washington, New Jersey.  It serves students from grades 9-12 in various vocations like Electronics, Engineering, or Culinary.

Web Site: http://www.wctech.org