### PR TITLE
Fix typo in mpi-inf.txt

### DIFF
--- a/lib/domains/de/mpi-inf.txt
+++ b/lib/domains/de/mpi-inf.txt
@@ -1,1 +1,1 @@
-Max-Planck Institute für Informatik
+Max-Planck-Institut für Informatik


### PR DESCRIPTION
The file now contains the correct german name. 

Feel free to quickly verify this pull request by performing a google search:

https://www.google.com/search?q=Max-Planck+Institut+für+Informatik