### PR TITLE
University of Amsterdam (Master in System and Network Engineering)

### DIFF
--- a/lib/domains/nl/os3.txt
+++ b/lib/domains/nl/os3.txt
@@ -1,0 +1,1 @@
+University of Amsterdam (Master in System and Network Engineering)


### PR DESCRIPTION
The SNE master uses their own domain name.