### PR TITLE
Create moe.txt

### DIFF
--- a/lib/domains/om/moe.txt
+++ b/lib/domains/om/moe.txt
@@ -1,0 +1,1 @@
+The Ministry of Education of Oman


### PR DESCRIPTION
Added the Ministry of Education of Oman. Teachers & students (only students of level/grade 12) of public schools are given an email under this domain.

Note: The domain name of the website is moe.gov.om but emails are given under the moe.om domain.
