### PR TITLE
Create net-ustu.ru

### DIFF
--- a/lib/domains/ru/net-ustu.txt
+++ b/lib/domains/ru/net-ustu.txt
@@ -1,0 +1,1 @@
+Ural State Technical University


### PR DESCRIPTION
New domain for Ural State Technical University, replacing old @ustu.ru.