### PR TITLE
Add edu.fh-joanneum.at

### DIFF
--- a/lib/domains/at/fh-joanneum/edu.txt
+++ b/lib/domains/at/fh-joanneum/edu.txt
@@ -1,0 +1,1 @@
+FH JOANNEUM


### PR DESCRIPTION
This is the new domain used for student email addresses at FH JOANNEUM, as detailed in this document at the end of page 2: https://hlpdsk.fh-joanneum.at/o365/Information_NewStudents_English_20130924.pdf

There might be students still using the legacy @fh-joanneum.at email addresses as they weren't automatically migrated. This is described here on page 2: https://hlpdsk.fh-joanneum.at/o365/Migration_Manual_english_20140804.pdf