### PR TITLE
Add Willits Charter School to .net domain

### DIFF
--- a/lib/domains/net/willitscharter.txt
+++ b/lib/domains/net/willitscharter.txt
@@ -1,0 +1,1 @@
+Willits Charter School


### PR DESCRIPTION
If you need to confirm with a website: http://www.willitscharter.org/

My schools website goes off the .org but emails on are .net for some odd reason.
