### PR TITLE
Create nure.ua

### DIFF
--- a/lib/domains/ua/nure.txt
+++ b/lib/domains/ua/nure.txt
@@ -1,0 +1,1 @@
+Kharkiv National University of Radio Electronics


### PR DESCRIPTION
Already exists kture.kharkov.ua, but from this year university provide this one new (nure.ua).
