### PR TITLE
Create wbais.txt

### DIFF
--- a/lib/domains/net/wbais.txt
+++ b/lib/domains/net/wbais.txt
@@ -1,0 +1,1 @@
+Walworth Barbour American International School


### PR DESCRIPTION
Walworth Barbour American International School (wbais.net)
This school does not provide tertiary education. See #1043.