### PR TITLE
Fix link to Wikipedia in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Hopefully, you'll be surprised by some of this:
 | Domain | Academic? | Comments |
 |--------|-----------|----------|
 |`stanford.edu`|:heavy_check_mark:|OK, this was an easy one so you could get at least *one* right|
-|`america.edu`|:heavy_multiplication_x:| Prior to October 29th 2001, anyone could register a `.edu` domain name ([details](http://en.wikipedia.org/wiki/.edu#Grandfathered_uses)) |
+|`america.edu`|:heavy_multiplication_x:| Prior to October 29th 2001, anyone could register a `.edu` domain name ([details](https://en.wikipedia.org/wiki/.edu#Grandfathered_uses)) |
 |`duep.edu`|:heavy_check_mark:| Alfred Nobel University is a *Ukranian* University *in the Ukraine* i.e. not in the USA :us: |
 |`gla.ac.uk`|:heavy_check_mark:|Glasgow University in Scotland|
 |`unizar.es`|:heavy_check_mark:|The University of Zaragoza in Spain|


### PR DESCRIPTION
Very minor commit; changed a link in README.md to use HTTPS instead of HTTP.
When HTTP is used, Wikipedia manually redirects users to the HTTPS page which causes the HTML anchor to get lost (the browser will no longer scroll to the relevant section of the page).
While this is obviously an issue with Wikipedia itself, I figured having the correct link wouldn't hurt.