### PR TITLE
University of Split Faculty of Civil Engineering, Architecture and Geodesy

### DIFF
--- a/lib/domains/hr/gradst.txt
+++ b/lib/domains/hr/gradst.txt
@@ -1,0 +1,1 @@
+University of Split Faculty of Civil Engineering, Architecture and Geodesy


### PR DESCRIPTION
University of Split Faculty of Civil Engineering, Architecture and Geodesy

Website: http://gradst.unist.hr/