### PR TITLE
added isi-mtl.com - Institut supérieur d'informatique

### DIFF
--- a/lib/domains/com/isi-mtl.txt
+++ b/lib/domains/com/isi-mtl.txt
@@ -1,0 +1,1 @@
+Institut superieur d'informatique


### PR DESCRIPTION
added a new school to the swot list of schools under lib/domains/com/isi-mtl.txt