### PR TITLE
Willingdon Community School (apple certified training centre)

### DIFF
--- a/lib/domains/uk/org/willingdonschool.txt
+++ b/lib/domains/uk/org/willingdonschool.txt
@@ -1,0 +1,1 @@
+Willingdon Community School (Certified Apple Training Centre)


### PR DESCRIPTION
#### Institution/School Name 
Willingdon Community School

#### Instiution/School Website
http://willingdonschool.org.uk

#### Email Users

*Please place an x between the square brackets if yes*
- [x] Students
- [x] Academic/Teaching Staff
- [x] Other/Support Staff

#### Education Levels

*Please place an x between the square brackets if yes*

- [ ] Post-graduate research
- [ ] Graduate School
- [ ] College (University) or Undergraduate School or equivalent
- [x] Community College or equivalent
- [x] High School or equivalent
- [ ] Elementary School or equivalent
