### PR TITLE
Corrected name of CAU Kiel

### DIFF
--- a/lib/domains/de/uni-kiel.txt
+++ b/lib/domains/de/uni-kiel.txt
@@ -1,1 +1,1 @@
-Christian-Albrechts-Universität Kiel
+Christian-Albrechts-Universität zu Kiel


### PR DESCRIPTION
#### Institution/School Name

Christian-Albrechts-Universität zu Kiel
#### Instiution/School Website

http://www.uni-kiel.de/

A "zu" was missing.
