### PR TITLE
Added HTL-Waidhofen

### DIFF
--- a/lib/domains/at/ac/htl-wy.txt
+++ b/lib/domains/at/ac/htl-wy.txt
@@ -1,0 +1,1 @@
+HTL Waidhofen an der Ybbs

--- a/lib/domains/at/htl-wy.txt
+++ b/lib/domains/at/htl-wy.txt
@@ -1,0 +1,1 @@
+HTL Waidhofen an der Ybbs


### PR DESCRIPTION
#### Institution/School Name 
HTL Waidhofen an der Ybbs
#### Instiution/School Website
https://www.htlwy.ac.at/homepage/

#### Email Users

*Please place an x between the square brackets if yes*
- [x ] Students
- [x ] Academic/Teaching Staff
- [ ] Other/Support Staff
- [ ] Alumni

#### Education Levels

*Please place an x between the square brackets if yes*

- [ ] Post-graduate research
- [ ] Graduate School
- [ ] College (University) or Undergraduate School or equivalent
- [ ] Community College or equivalent
- [x ] High School or equivalent
- [ ] Elementary School or equivalent
