### PR TITLE
Updates Plymouth University name.

### DIFF
--- a/lib/domains/uk/ac/plymouth.txt
+++ b/lib/domains/uk/ac/plymouth.txt
@@ -1,1 +1,1 @@
-University of Plymouth
+Plymouth University


### PR DESCRIPTION
This is my alma mater. Around 2011 they started the movement to rebrand as 'Plymouth University'. https://www.plymouth.ac.uk/

Fantastic gem, found out about it from @olivierlacan and excited to make my small contribution!