### PR TITLE
Add Singaporean post-secondary educational institutions

### DIFF
--- a/lib/domains/sg/com/saa.txt
+++ b/lib/domains/sg/com/saa.txt
@@ -1,0 +1,1 @@
+Singapore Aviation Academy

--- a/lib/domains/sg/edu/bcaa.txt
+++ b/lib/domains/sg/edu/bcaa.txt
@@ -1,0 +1,1 @@
+BCA Academy

--- a/lib/domains/sg/edu/ite.txt
+++ b/lib/domains/sg/edu/ite.txt
@@ -1,0 +1,1 @@
+Institute of Technical Education

--- a/lib/domains/sg/edu/lasalle.txt
+++ b/lib/domains/sg/edu/lasalle.txt
@@ -1,0 +1,1 @@
+LASALLE College of the Arts

--- a/lib/domains/sg/edu/nafa.txt
+++ b/lib/domains/sg/edu/nafa.txt
@@ -1,0 +1,1 @@
+Nanyang Academy of Fine Arts

--- a/lib/domains/sg/edu/np.txt
+++ b/lib/domains/sg/edu/np.txt
@@ -1,0 +1,1 @@
+Ngee Ann Polytechnic

--- a/lib/domains/sg/edu/nyp.txt
+++ b/lib/domains/sg/edu/nyp.txt
@@ -1,0 +1,1 @@
+Nanyang Polytechnic

--- a/lib/domains/sg/edu/rp.txt
+++ b/lib/domains/sg/edu/rp.txt
@@ -1,0 +1,1 @@
+Republic Polytechnic

--- a/lib/domains/sg/edu/sp.txt
+++ b/lib/domains/sg/edu/sp.txt
@@ -1,0 +1,1 @@
+Singapore Polytechnic

--- a/lib/domains/sg/edu/suss.txt
+++ b/lib/domains/sg/edu/suss.txt
@@ -1,0 +1,1 @@
+Singapore University of Social Sciences

--- a/lib/domains/sg/edu/sutd.txt
+++ b/lib/domains/sg/edu/sutd.txt
@@ -1,0 +1,1 @@
+Singapore University of Technology and Design

--- a/lib/domains/sg/edu/tp.txt
+++ b/lib/domains/sg/edu/tp.txt
@@ -1,0 +1,1 @@
+Temasek Polytechnic

--- a/lib/domains/sg/edu/unisim.txt
+++ b/lib/domains/sg/edu/unisim.txt
@@ -1,0 +1,1 @@
+Singapore University of Social Sciences


### PR DESCRIPTION
Source: https://www.moe.gov.sg/education/post-secondary

#### Institution/School Name 
Singapore Aviation Academy
BCA Academy
Institute of Technical Education
LASALLE College of the Arts
Nanyang Academy of Fine Arts
Ngee Ann Polytechnic
Nanyang Polytechnic
Republic Polytechnic
Singapore Polytechnic
Singapore University of Social Sciences
Singapore University of Technology and Design
Temasek Polytechnic
Singapore University of Social Sciences (Formerly known as UniSIM)

#### Institution/School Website
saa.com.sg
bcaa.edu.sg
ite.edu.sg
lasalle.edu.sg
nafa.edu.sg
np.edu.sg
nyp.edu.sg
rp.edu.sg
sp.edu.sg
suss.edu.sg
sutd.edu.sg
tp.edu.sg
unisim.edu.sg

#### Email Users

*Please place an x between the square brackets if yes*
- [x] Students
- [x] Academic/Teaching Staff
- [x] Other/Support Staff
- [x] Alumni

#### Education Levels

*Please place an x between the square brackets if yes*

- [x] Post-graduate research
- [x] Graduate School
- [x] College (University) or Undergraduate School or equivalent
- [ ] Community College or equivalent
- [ ] High School or equivalent
- [ ] Elementary School or equivalent
