### PR TITLE
Added: Tekstilno-Tehnološki fakultet Zagreb, part of a University of …

### DIFF
--- a/lib/domains/hr/ttf.txt
+++ b/lib/domains/hr/ttf.txt
@@ -1,0 +1,2 @@
+Tekstilno-tehnološki fakultet, Sveučilišta u Zagrebu
+Faculty of Textile and Technology, Univeristy of Zagreb


### PR DESCRIPTION

#### Institution/School Name 
Tekstilno-tehnološki fakultet, Sveučilišta u Zagrebu

#### Instiution/School Website
http://www.ttf.unizg.hr/

#### Email Users

*Please place an x between the square brackets if yes*
- [x] Students
- [ ] Academic/Teaching Staff
- [ ] Other/Support Staff
- [ ] Alumni

#### Education Levels

*Please place an x between the square brackets if yes*

- [x] Post-graduate research
- [ ] Graduate School
- [ ] College (University) or Undergraduate School or equivalent
- [ ] Community College or equivalent
- [ ] High School or equivalent
- [ ] Elementary School or equivalent
