### PR TITLE
Add knu.ua for National Taras Shevchenko University of Kiev

### DIFF
--- a/lib/domains/ua/knu.txt
+++ b/lib/domains/ua/knu.txt
@@ -1,0 +1,1 @@
+National Taras Shevchenko University of Kiev


### PR DESCRIPTION
knu.ua is the second domain for student emails, together with univ.kiev.ua

#### Institution/School Name 
National Taras Shevchenko University of Kiev

#### Instiution/School Website
knu.ua

#### Email Users

*Please place an x between the square brackets if yes*
- [x] Students
- [ ] Academic/Teaching Staff
- [ ] Other/Support Staff
- [ ] Alumni

#### Education Levels

*Please place an x between the square brackets if yes*

- [ ] Post-graduate research
- [ ] Graduate School
- [x] College (University) or Undergraduate School or equivalent
- [ ] Community College or equivalent
- [ ] High School or equivalent
- [ ] Elementary School or equivalent
