### PR TITLE
KHLeuven and KHLim migrated into UCLL, University College Leuven-Limburg

### DIFF
--- a/lib/domains/be/khleuven.txt
+++ b/lib/domains/be/khleuven.txt
@@ -1,1 +1,0 @@
-Katholieke Hogeschool Leuven

--- a/lib/domains/be/khlim.txt
+++ b/lib/domains/be/khlim.txt
@@ -1,1 +1,0 @@
-Katholieke Hogeschool Limburg

--- a/lib/domains/be/ucll.txt
+++ b/lib/domains/be/ucll.txt
@@ -1,0 +1,1 @@
+University College Leuven-Limburg


### PR DESCRIPTION
The KHLeuven (Katholieke Hogeschool Leuven) and KHLim (Katholieke Hogeschool Limburg)
migrated into one group called UCLL (University College Leuven-Limburg).
Both the domains khleuven.be and khlim.be forward to ucll.be, and the
old email addresses are no longer in use.

#### Institution/School Name 
University College Leuven-Limburg

#### Instiution/School Website
* [khleuven.be](https://khleuven.be)
* [khlim.be](http://khlim.be)

migrated into: [ucll.be](https://www.ucll.be/international/about)

#### Email Users

*Please place an x between the square brackets if yes*
- [x] Students
- [x] Academic/Teaching Staff
- [x] Other/Support Staff
- [ ] Alumni

#### Education Levels

*Please place an x between the square brackets if yes*

- [ ] Post-graduate research
- [ ] Graduate School
- [x] College (University) or Undergraduate School or equivalent
- [ ] Community College or equivalent
- [ ] High School or equivalent
- [ ] Elementary School or equivalent
