### PR TITLE
Create o365sen.txt

### DIFF
--- a/lib/domains/net/o365sen.txt
+++ b/lib/domains/net/o365sen.txt
@@ -1,0 +1,1 @@
+Seoul Metropolitan Office of Education


### PR DESCRIPTION
All Korean schools in the Seoul Metropolitan Office of Education use the o365sen.net domain, which can be obtained through student certification at o365edu.net. o365edu.net is the website of POBIS TNC. It is operated by the majority of the education offices in Korea including the Seoul Metropolitan Office of Education. As you can see at http://www.o365edu.net/JoinStep2.aspx?type=student, you will not get this email without student verification. So I think the domain should be added.

#### Institution/School Name 
Seoul Metropolitan Office of Education

#### Instiution/School Website
http://o365edu.net
http://sen.go.kr/

#### Email Users

*Please place an x between the square brackets if yes*
- [x] Students
- [ ] Academic/Teaching Staff
- [ ] Other/Support Staff
- [ ] Alumni

#### Education Levels

*Please place an x between the square brackets if yes*

- [ ] Post-graduate research
- [ ] Graduate School
- [x] College (University) or Undergraduate School or equivalent
- [ ] Community College or equivalent
- [x] High School or equivalent
- [x] Elementary School or equivalent
