### PR TITLE
add Royal Grammar School, High Wycombe

### DIFF
--- a/lib/domains/com/rgshw.txt
+++ b/lib/domains/com/rgshw.txt
@@ -1,0 +1,1 @@
+Royal Grammar School, High Wycombe


### PR DESCRIPTION
#### Institution/School Name 
Royal Grammar School, High Wycombe

#### Instiution/School Website
https://www.rgshw.com/

#### Email Users

*Please place an x between the square brackets if yes*
- [x] Students
- [x] Academic/Teaching Staff
- [x] Other/Support Staff
- [ ] Alumni

#### Education Levels

*Please place an x between the square brackets if yes*

- [ ] Post-graduate research
- [ ] Graduate School
- [ ] College (University) or Undergraduate School or equivalent
- [ ] Community College or equivalent
- [x] High School or equivalent
- [ ] Elementary School or equivalent
