### PR TITLE
Added domain for Universitat Oberta de Catalunya (uoc.edu)

### DIFF
--- a/lib/domains/edu/uoc.txt
+++ b/lib/domains/edu/uoc.txt
@@ -1,0 +1,1 @@
+Universitat Oberta de Catalunya


### PR DESCRIPTION
#### Institution/School Name 
Universitat Oberta de Catalunya

#### Instiution/School Website
http://www.uoc.edu

#### Email Users

*Please place an x between the square brackets if yes*
- [x] Students
- [x] Academic/Teaching Staff
- [x] Other/Support Staff
- [ ] Alumni

#### Education Levels

*Please place an x between the square brackets if yes*

- [x] Post-graduate research
- [x] Graduate School
- [x] College (University) or Undergraduate School or equivalent
- [ ] Community College or equivalent
- [ ] High School or equivalent
- [ ] Elementary School or equivalent
