### PR TITLE
Technical College of Computer Science "J. Ph. Fallmerayer", Brixen

### DIFF
--- a/lib/domains/it/fallmerayer/bx.txt
+++ b/lib/domains/it/fallmerayer/bx.txt
@@ -1,0 +1,1 @@
+Technical College of Computer Science "J. Ph. Fallmerayer", Brixen


### PR DESCRIPTION
#### Institution/School Name 
Technical College of Computer Science "J. Ph. Fallmerayer", Brixen

German:
TFO Fachrichtung Informatik  "J. Ph. Fallmerayer", Brixen

#### Instiution/School Website
http://fallmerayer.it/technologische-fachrichtung-fallmerayer-brixen-informatik-ex-gewerbeoberschule.html

#### Email Users

*Please place an x between the square brackets if yes*
- [X] Students
- [X] Academic/Teaching Staff
- [ ] Other/Support Staff
- [ ] Alumni

#### Education Levels

*Please place an x between the square brackets if yes*

- [ ] Post-graduate research
- [ ] Graduate School
- [X] College (University) or Undergraduate School or equivalent
- [ ] Community College or equivalent
- [ ] High School or equivalent
- [ ] Elementary School or equivalent
