### PR TITLE
Add Faculty of Science Damanhour University

### DIFF
--- a/lib/domains/eg/edu/dmu/sci.txt
+++ b/lib/domains/eg/edu/dmu/sci.txt
@@ -1,0 +1,1 @@
+Faculty of Science - Damanhour University 


### PR DESCRIPTION
add Damanhour University which is a publice university in Egypt,
Damanhour City.
This is Damanhour University website: www.damanhour.edu.eg
Unfortunatily, We do not have a dedicated webpage for every course we
have. But, we have CS department in the faculty of science and it offers
computer science program as a major/minor, you can check it from this URL:
www.damanhour.edu.eg/scimfac/Pages/Page.aspx?id=550
I am not sure I know what could be a proof of the university recognition
of this domain, but you might consider contacting: info.mis@dmu.edu.eg

#### Institution/School Name 
{Damanhour University - Faculty of science}

#### Instiution/School Website
{www.damanhour.edu.eg}

#### Email Users

*Please place an x between the square brackets if yes*
- [x] Students
- [x] Academic/Teaching Staff
- [ ] Other/Support Staff
- [ ] Alumni

#### Education Levels

*Please place an x between the square brackets if yes*

- [ ] Post-graduate research
- [x] Graduate School
- [x] College (University) or Undergraduate School or equivalent
- [ ] Community College or equivalent
- [ ] High School or equivalent
- [ ] Elementary School or equivalent
